### PR TITLE
SES-700 port pluginlib to new macro

### DIFF
--- a/src/image_undistort_nodelet.cpp
+++ b/src/image_undistort_nodelet.cpp
@@ -15,6 +15,4 @@ class ImageUndistortNodelet : public nodelet::Nodelet {
 };
 }
 
-PLUGINLIB_DECLARE_CLASS(image_undistort, ImageUndistortNodelet,
-                        image_undistort::ImageUndistortNodelet,
-                        nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(image_undistort::ImageUndistortNodelet, nodelet::Nodelet);

--- a/src/stereo_info_nodelet.cpp
+++ b/src/stereo_info_nodelet.cpp
@@ -15,5 +15,4 @@ class StereoInfoNodelet : public nodelet::Nodelet {
 };
 }
 
-PLUGINLIB_DECLARE_CLASS(image_undistort, StereoInfoNodelet,
-                        image_undistort::StereoInfoNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(image_undistort::StereoInfoNodelet, nodelet::Nodelet);

--- a/src/stereo_undistort_nodelet.cpp
+++ b/src/stereo_undistort_nodelet.cpp
@@ -15,6 +15,4 @@ class StereoUndistortNodelet : public nodelet::Nodelet {
 };
 }
 
-PLUGINLIB_DECLARE_CLASS(image_undistort, StereoUndistortNodelet,
-                        image_undistort::StereoUndistortNodelet,
-                        nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(image_undistort::StereoUndistortNodelet, nodelet::Nodelet);


### PR DESCRIPTION
Port all pluginlib interactions to then new support macros.
PLUGINLIB_DECLARE_CLASS has been deprecated and needs to be replaced by PLUGINLIB_EXPORT_CLASS

This is in preparation for upgrading pluginlib


@v-mehta
@mikepurvis